### PR TITLE
fixed nb name and updated 2021 links --> 2022

### DIFF
--- a/amplicon_analysis.ipynb
+++ b/amplicon_analysis.ipynb
@@ -900,7 +900,7 @@
     "\n",
     "Another common question in microbial ecology research is to ask \"who is there\"? We have a set of sequences derived from our samples, and the next step is to classify these to predict the nearest taxonomic lineage (e.g., to detect known pathogens or other functionally important species). There are many approaches, some based on DNA sequence alignment and others based on machine learning models (e.g., using subsequence signatures).\n",
     "\n",
-    "Here we will use a [Naïve Bayes classifier](https://en.wikipedia.org/wiki/Naive_Bayes_classifier) trained on k-mer frequencies derived from the GreenGenes 16S rRNA gene database. A pre-trained classifier can be downloaded from https://docs.qiime2.org/2021.4/data-resources/.\n",
+    "Here we will use a [Naïve Bayes classifier](https://en.wikipedia.org/wiki/Naive_Bayes_classifier) trained on k-mer frequencies derived from the GreenGenes 16S rRNA gene database. A pre-trained classifier can be downloaded from https://docs.qiime2.org/2022.2/data-resources/.\n",
     "\n",
     "Microbial taxonomy is a thorny topic that we don't have time to brush on now. "
    ]
@@ -916,7 +916,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://data.qiime2.org/2021.8/common/gg-13-8-99-515-806-nb-classifier.qza"
+    "!wget https://data.qiime2.org/2022.2/common/gg-13-8-99-515-806-nb-classifier.qza"
    ]
   },
   {
@@ -976,7 +976,7 @@
     }
    },
    "source": [
-    "We can also collapse data on a particular taxonomic rank using the QIIME 2 [taxa plugin](https://docs.qiime2.org/2021.4/plugins/available/taxa/). Why might we want to look at different taxonomic ranks, rather than just looking at ASVs?"
+    "We can also collapse data on a particular taxonomic rank using the QIIME 2 [q2-taxa plugin](https://docs.qiime2.org/2022.2/plugins/available/taxa/). Why might we want to look at different taxonomic ranks, rather than just looking at ASVs?"
    ]
   },
   {
@@ -1241,7 +1241,7 @@
   "colab": {
    "collapsed_sections": [],
    "include_colab_link": true,
-   "name": "16S_2021.ipynb",
+   "name": "amplicon_analysis.ipynb",
    "provenance": [],
    "toc_visible": true
   },


### PR DESCRIPTION
I discovered how to rename the notebook name... evidently the old name was stored in some colab metadata inside the ipynb.

Also found some 2021 links in the process, updated to 2022.2